### PR TITLE
Improve performance with JEI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ dependencies {
     deobfCompile "net.darkhax.bookshelf:Bookshelf-1.12.2:${version_bookshelf}"
     deobfCompile "net.darkhax.gamestages:GameStages-1.12.2:${version_gamestages}"
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${version_minetweaker}"
-    deobfCompile "mezz.jei:jei_1.12.2:${version_jei}"
+    deobfProvided "mezz.jei:jei_1.12.2:${version_jei}:api"
+    runtime "mezz.jei:jei_1.12.2:${version_jei}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ curse_versions=1.12.2
 curse_requirements=crafttweaker, game-stages
 curse_project=280316
 
-version_bookshelf=2.2.488
+version_bookshelf=2.2.489
 version_minetweaker=4.0.9.285
 version_gamestages=1.0.71
-version_jei=4.8.0.111
+version_jei=4.8.2.123

--- a/src/main/java/net/darkhax/itemstages/ItemEntry.java
+++ b/src/main/java/net/darkhax/itemstages/ItemEntry.java
@@ -31,23 +31,7 @@ public class ItemEntry {
             }
         }
 
-        return "";
-    }
-
-    public boolean hasStack (ItemStack stack) {
-
-        for (final Entry<String, ItemStack[]> entry : this.entries.entrySet()) {
-
-            for (final ItemStack entryStack : entry.getValue()) {
-
-                if (StackUtils.areStacksSimilarWithPartialNBT(entryStack, stack)) {
-
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return null;
     }
 
     public void add (String stage, ItemStack[] entries) {

--- a/src/main/java/net/darkhax/itemstages/ItemStages.java
+++ b/src/main/java/net/darkhax/itemstages/ItemStages.java
@@ -1,6 +1,6 @@
 package net.darkhax.itemstages;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -31,24 +31,30 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@Mod(modid = "itemstages", name = "Item Stages", version = "@VERSION@", dependencies = "after:jei@[4.8.0.110,);required-after:bookshelf@[2.2.489,);required-after:gamestages@[1.0.67,);required-after:crafttweaker@[2.7.2.,)", certificateFingerprint = "@FINGERPRINT@")
+@Mod(modid = "itemstages", name = "Item Stages", version = "@VERSION@", dependencies = "after:jei@[4.8.2.123,);required-after:bookshelf@[2.2.489,);required-after:gamestages@[1.0.67,);required-after:crafttweaker@[2.7.2.,)", certificateFingerprint = "@FINGERPRINT@")
 public class ItemStages {
 
     public static final LoggingHelper LOG = new LoggingHelper("Item Stages");
 
-    public static final Map<Item, ItemEntry> ITEM_STAGES = new HashMap<>();
+    public static final Map<Item, ItemEntry> ITEM_STAGES = new IdentityHashMap<>();
 
-    public static ItemEntry getEntry (ItemStack stack) {
+    public static String getStage (ItemStack stack) {
 
         final ItemEntry entry = ITEM_STAGES.get(stack.getItem());
-        return entry != null && entry.hasStack(stack) ? entry : null;
+
+        if (entry == null) {
+
+            return null;
+        }
+
+        return entry.getStage(stack);
     }
 
     public static void addEntry (Item item, ItemEntry entry) {
 
-        if (ITEM_STAGES.containsKey(item)) {
+        final ItemEntry existing = ITEM_STAGES.get(item);
 
-            final ItemEntry existing = ITEM_STAGES.get(item);
+        if (existing != null) {
 
             for (final Entry<String, ItemStack[]> entries : entry.entries.entrySet()) {
 
@@ -74,17 +80,17 @@ public class ItemStages {
 
         if (stageData != null) {
 
-            final ItemEntry entry = getEntry(stack);
+            final String stage = getStage(stack);
 
             // No restrictions
-            if (entry == null) {
+            if (stage == null) {
 
                 return false;
             }
 
             else {
 
-                return !stageData.hasUnlockedStage(entry.getStage(stack));
+                return !stageData.hasUnlockedStage(stage);
             }
         }
 
@@ -136,14 +142,14 @@ public class ItemStages {
 
         if (!event.getItemStack().isEmpty() && isRestricted(event.getEntityPlayer(), event.getItemStack())) {
 
-            final ItemEntry entry = getEntry(event.getItemStack());
+            final String stage = getStage(event.getItemStack());
 
-            if (entry != null) {
+            if (stage != null) {
 
                 event.getToolTip().clear();
                 event.getToolTip().add(TextFormatting.WHITE + "Restricted Item");
                 event.getToolTip().add(TextFormatting.RED + "" + TextFormatting.ITALIC + "Further progression is required to access this item.");
-                event.getToolTip().add(TextFormatting.RED + "You need stage " + entry.getStage(event.getItemStack()) + " first.");
+                event.getToolTip().add(TextFormatting.RED + "You need stage " + stage + " first.");
             }
         }
     }

--- a/src/main/java/net/darkhax/itemstages/jei/PluginItemStages.java
+++ b/src/main/java/net/darkhax/itemstages/jei/PluginItemStages.java
@@ -1,6 +1,7 @@
 package net.darkhax.itemstages.jei;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -10,6 +11,7 @@ import mezz.jei.api.IModRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.ingredients.IIngredientBlacklist;
 import mezz.jei.api.ingredients.IIngredientRegistry;
+import net.darkhax.gamestages.capabilities.PlayerDataHandler;
 import net.darkhax.itemstages.ItemEntry;
 import net.darkhax.itemstages.ItemStages;
 import net.minecraft.client.Minecraft;
@@ -48,33 +50,32 @@ public class PluginItemStages implements IModPlugin {
             final Set<ItemStack> toBlacklist = new HashSet<>();
             final Set<ItemStack> toWhitelist = new HashSet<>();
 
+            final PlayerDataHandler.IStageData stageData = PlayerDataHandler.getStageData(player);
+
             for (final Entry<Item, ItemEntry> entry : ItemStages.ITEM_STAGES.entrySet()) {
 
                 for (final Entry<String, ItemStack[]> stageEntry : entry.getValue().entries.entrySet()) {
 
-                    for (final ItemStack stack : stageEntry.getValue()) {
+                    if (stageData.hasUnlockedStage(stageEntry.getKey())) {
 
-                        if (ItemStages.isRestricted(player, stack)) {
+                        Collections.addAll(toWhitelist, stageEntry.getValue());
+                    }
 
-                            toBlacklist.add(stack);
-                        }
+                    else {
 
-                        else {
-
-                            toWhitelist.add(stack);
-                        }
+                        Collections.addAll(toBlacklist, stageEntry.getValue());
                     }
                 }
             }
 
             if (!toBlacklist.isEmpty()) {
 
-                ingredientRegistry.removeIngredientsAtRuntime(ItemStack.class, new ArrayList<>(toBlacklist));
+                ingredientRegistry.removeIngredientsAtRuntime(ItemStack.class, toBlacklist);
             }
 
             if (!toWhitelist.isEmpty()) {
 
-                ingredientRegistry.addIngredientsAtRuntime(ItemStack.class, new ArrayList<>(toWhitelist));
+                ingredientRegistry.addIngredientsAtRuntime(ItemStack.class, toWhitelist);
             }
 
             ItemStages.LOG.info("Finished JEI Sync, took " + (System.currentTimeMillis() - time) + "ms. " + toBlacklist.size() + " hidden, " + toWhitelist.size() + " shown.");


### PR DESCRIPTION
Before:
`Finished JEI Sync, took 2197ms. 13769 hidden, 0 shown.`
after PR:
`Finished JEI Sync, took 377ms. 13769 hidden, 0 shown.`

Unfortunately I did not have much time to test this change very thoroughly, but changes are small and the logic should be the same.

This does not fix https://github.com/Darkosto/SevTech-Ages/issues/202, but when both of these are fixed then things should run very smoothly!